### PR TITLE
Fix cannon shot logic

### DIFF
--- a/scenes/rook.tscn
+++ b/scenes/rook.tscn
@@ -13,6 +13,7 @@ size = Vector2(79, 78)
 [node name="Rook" type="CharacterBody2D" groups=["playerAttack"]]
 motion_mode = 1
 script = ExtResource("1_ih210")
+cannon_offset = 50
 
 [node name="RookSprite" type="Sprite2D" parent="."]
 texture = ExtResource("1_fdtut")

--- a/src/cannon_shot.gd
+++ b/src/cannon_shot.gd
@@ -5,11 +5,17 @@ var direction: Vector2 = Vector2.ZERO
 
 func _init() -> void:
 	body_entered.connect(on_body_entered)
+	area_entered.connect(on_area_entered)
 
 func _physics_process(delta: float) -> void:
 	position += direction * speed * delta
 
 func on_body_entered(body: Node) -> void:
 	print("Cannon shot hit: ", body.name)
+	# TODO: damage logic
+	queue_free()
+
+func on_area_entered(area: Area2D) -> void:
+	print("Cannon shot hit area: ", area.name)
 	# TODO: damage logic
 	queue_free()


### PR DESCRIPTION
Fixes:
1) cannon shot despawning if you shoot down as it interacts with rook area
2) cannon not despawning upon hitting hitbox area2ds